### PR TITLE
Enable in/contains operations for strings to do substring matches

### DIFF
--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -96,6 +96,10 @@ var evaluateTests map[string]expressionTest = map[string]expressionTest{
 			{expression: "String == `not-it`", result: false, benchQuick: true},
 			{expression: "String != `exported`", result: false},
 			{expression: "String != `not-it`", result: true},
+			{expression: "port in String", result: true, benchQuick: true},
+			{expression: "part in String", result: false},
+			{expression: "port not in String", result: false},
+			{expression: "part not in String", result: true},
 			{expression: "unexported == `unexported`", result: false, err: "Selector \"unexported\" is not valid"},
 			{expression: "Hidden == false", result: false, err: "Selector \"Hidden\" is not valid"},
 		},
@@ -253,6 +257,7 @@ var evaluateTests map[string]expressionTest = map[string]expressionTest{
 		},
 		[]expressionCheck{
 			{expression: "Nested.Map.foo == bar", result: true, benchQuick: true},
+			{expression: "Nested.Map.foo contains ba", result: true, benchQuick: true},
 			{expression: "Nested.Map.foo == baz", result: false},
 			{expression: "Nested.Map is not empty", result: true},
 			{expression: "Nested.Map is not empty", result: true},

--- a/field_config.go
+++ b/field_config.go
@@ -71,9 +71,13 @@ func generateFieldConfigurationInternal(rtype reflect.Type) (*FieldConfiguration
 
 	// Handle primitive types
 	if coerceFn, ok := primitiveCoercionFns[rtype.Kind()]; ok {
+		ops := []MatchOperator{MatchEqual, MatchNotEqual}
+		if rtype.Kind() == reflect.String {
+			ops = append(ops, MatchIn, MatchNotIn)
+		}
 		return &FieldConfiguration{
 			CoerceFn:            coerceFn,
-			SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual},
+			SupportedOperations: ops,
 		}, nil
 	}
 

--- a/field_config_test.go
+++ b/field_config_test.go
@@ -30,7 +30,7 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 			"Float32": &FieldConfiguration{StructFieldName: "Float32", CoerceFn: CoerceFloat32, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 			"Float64": &FieldConfiguration{StructFieldName: "Float64", CoerceFn: CoerceFloat64, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 			"Bool":    &FieldConfiguration{StructFieldName: "Bool", CoerceFn: CoerceBool, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-			"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+			"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 		},
 		benchQuick: true,
 	},
@@ -57,12 +57,12 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 		expected: FieldConfigurations{
 			"Nested": &FieldConfiguration{StructFieldName: "Nested", SubFields: FieldConfigurations{
 				"Map": &FieldConfiguration{StructFieldName: "Map", SupportedOperations: []MatchOperator{MatchIn, MatchNotIn, MatchIsEmpty, MatchIsNotEmpty}, SubFields: FieldConfigurations{
-					FieldNameAny: &FieldConfiguration{StructFieldName: "", SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+					FieldNameAny: &FieldConfiguration{StructFieldName: "", SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 				}},
 				"MapOfStructs": &FieldConfiguration{StructFieldName: "MapOfStructs", SupportedOperations: []MatchOperator{MatchIsEmpty, MatchIsNotEmpty, MatchIn, MatchNotIn}, SubFields: FieldConfigurations{
 					FieldNameAny: &FieldConfiguration{StructFieldName: "", SubFields: FieldConfigurations{
 						"Foo": &FieldConfiguration{StructFieldName: "Foo", CoerceFn: CoerceInt, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-						"Baz": &FieldConfiguration{StructFieldName: "Baz", SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+						"Baz": &FieldConfiguration{StructFieldName: "Baz", SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 					}},
 				}},
 				"MapInfInf":   &FieldConfiguration{StructFieldName: "MapInfInf", SupportedOperations: []MatchOperator{MatchIsEmpty, MatchIsNotEmpty}},
@@ -94,7 +94,7 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 				"Float32": &FieldConfiguration{StructFieldName: "Float32", CoerceFn: CoerceFloat32, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 				"Float64": &FieldConfiguration{StructFieldName: "Float64", CoerceFn: CoerceFloat64, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 				"Bool":    &FieldConfiguration{StructFieldName: "Bool", CoerceFn: CoerceBool, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-				"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+				"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 			}},
 			"bar": &FieldConfiguration{SubFields: FieldConfigurations{
 				"Int":     &FieldConfiguration{StructFieldName: "Int", CoerceFn: CoerceInt, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
@@ -110,7 +110,7 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 				"Float32": &FieldConfiguration{StructFieldName: "Float32", CoerceFn: CoerceFloat32, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 				"Float64": &FieldConfiguration{StructFieldName: "Float64", CoerceFn: CoerceFloat64, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 				"Bool":    &FieldConfiguration{StructFieldName: "Bool", CoerceFn: CoerceBool, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-				"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+				"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 			}},
 			"baz": &FieldConfiguration{SubFields: FieldConfigurations{
 				"Int":     &FieldConfiguration{StructFieldName: "Int", CoerceFn: CoerceInt, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
@@ -126,7 +126,7 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 				"Float32": &FieldConfiguration{StructFieldName: "Float32", CoerceFn: CoerceFloat32, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 				"Float64": &FieldConfiguration{StructFieldName: "Float64", CoerceFn: CoerceFloat64, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 				"Bool":    &FieldConfiguration{StructFieldName: "Bool", CoerceFn: CoerceBool, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-				"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+				"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 			}},
 		},
 		benchQuick: true,
@@ -149,7 +149,7 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 					"Float32": &FieldConfiguration{StructFieldName: "Float32", CoerceFn: CoerceFloat32, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 					"Float64": &FieldConfiguration{StructFieldName: "Float64", CoerceFn: CoerceFloat64, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 					"Bool":    &FieldConfiguration{StructFieldName: "Bool", CoerceFn: CoerceBool, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-					"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+					"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 				}},
 				"bar": &FieldConfiguration{SubFields: FieldConfigurations{
 					"Int":     &FieldConfiguration{StructFieldName: "Int", CoerceFn: CoerceInt, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
@@ -165,7 +165,7 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 					"Float32": &FieldConfiguration{StructFieldName: "Float32", CoerceFn: CoerceFloat32, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 					"Float64": &FieldConfiguration{StructFieldName: "Float64", CoerceFn: CoerceFloat64, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 					"Bool":    &FieldConfiguration{StructFieldName: "Bool", CoerceFn: CoerceBool, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-					"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+					"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 				}},
 				"baz": &FieldConfiguration{SubFields: FieldConfigurations{
 					"Int":     &FieldConfiguration{StructFieldName: "Int", CoerceFn: CoerceInt, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
@@ -181,7 +181,7 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 					"Float32": &FieldConfiguration{StructFieldName: "Float32", CoerceFn: CoerceFloat32, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 					"Float64": &FieldConfiguration{StructFieldName: "Float64", CoerceFn: CoerceFloat64, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
 					"Bool":    &FieldConfiguration{StructFieldName: "Bool", CoerceFn: CoerceBool, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
-					"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual}},
+					"String":  &FieldConfiguration{StructFieldName: "String", CoerceFn: CoerceString, SupportedOperations: []MatchOperator{MatchEqual, MatchNotEqual, MatchIn, MatchNotIn}},
 				}},
 			}},
 		},


### PR DESCRIPTION
Apparently I had partially implemented this before (or rather didn't fully remove it prior to cutting the first release.

This PR just puts back in place the code to generate the field configurations that indicate that the contains/in operations can be used with string. The code already existed in the evaluation logic to handle those operations for strings.