### PR TITLE
Fix panic when primitive equality fn not found

### DIFF
--- a/evaluate.go
+++ b/evaluate.go
@@ -2,6 +2,7 @@ package bexpr
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -89,6 +90,9 @@ func doMatchMatches(expression *grammar.MatchExpression, value reflect.Value) (b
 func doMatchEqual(expression *grammar.MatchExpression, value reflect.Value) (bool, error) {
 	// NOTE: see preconditions in evaluategrammar.MatchExpressionRecurse
 	eqFn := primitiveEqualityFn(value.Kind())
+	if eqFn == nil {
+		return false, errors.New("unable to find suitable primitive comparison function for matching")
+	}
 	matchValue, err := getMatchExprValue(expression, value.Kind())
 	if err != nil {
 		return false, fmt.Errorf("error getting match value in expression: %w", err)
@@ -116,6 +120,9 @@ func doMatchIn(expression *grammar.MatchExpression, value reflect.Value) (bool, 
 			return false, fmt.Errorf("error getting match value in expression: %w", err)
 		}
 		eqFn := primitiveEqualityFn(itemType.Kind())
+		if eqFn == nil {
+			return false, errors.New(`unable to find suitable primitive comparison function for "in" comparison`)
+		}
 
 		for i := 0; i < value.Len(); i++ {
 			item := value.Index(i)

--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -265,6 +265,7 @@ var evaluateTests map[string]expressionTest = map[string]expressionTest{
 			{expression: "Nested.Map contains nope or (Nested.Map contains bar and Nested.Map.bar == `bazel`) or TopInt != 0", result: true, benchQuick: true},
 			{expression: "Nested.MapOfStructs.one.Foo == 42", result: true},
 			{expression: "7 in Nested.SliceOfInts", result: true},
+			{expression: `"/Nested/SliceOfInts" == "7"`, result: false, err: `unable to find suitable primitive comparison function for matching`},
 			{expression: "Nested.MapOfStructs is empty or (Nested.SliceOfInts contains 7 and 9 in Nested.SliceOfInts)", result: true, benchQuick: true},
 			{expression: "Nested.SliceOfStructs.0.X == 1", result: true},
 			{expression: "Nested.SliceOfStructs.0.Y == 4", result: false},


### PR DESCRIPTION
If a primitive equality function cannot be found it returns nil, but
currently the code does not check for this condition. This fixes it and
adds a test that panics without the change.