### PR TITLE
WithUnknownValue to treat unknown values as a non-error

### DIFF
--- a/bexpr.go
+++ b/bexpr.go
@@ -23,6 +23,7 @@ type Evaluator struct {
 	ast                     grammar.Expression
 	tagName                 string
 	valueTransformationHook ValueTransformationHookFn
+	unknownVal              *interface{}
 }
 
 func CreateEvaluator(expression string, opts ...Option) (*Evaluator, error) {
@@ -41,11 +42,20 @@ func CreateEvaluator(expression string, opts ...Option) (*Evaluator, error) {
 		ast:                     ast.(grammar.Expression),
 		tagName:                 parsedOpts.withTagName,
 		valueTransformationHook: parsedOpts.withHookFn,
+		unknownVal:              parsedOpts.withUnknown,
 	}
 
 	return eval, nil
 }
 
 func (eval *Evaluator) Evaluate(datum interface{}) (bool, error) {
-	return evaluate(eval.ast, datum, WithTagName(eval.tagName), WithHookFn(eval.valueTransformationHook))
+	opts := []Option{
+		WithTagName(eval.tagName),
+		WithHookFn(eval.valueTransformationHook),
+	}
+	if eval.unknownVal != nil {
+		opts = append(opts, WithUnknownValue(*eval.unknownVal))
+	}
+
+	return evaluate(eval.ast, datum, opts...)
 }

--- a/evaluate.go
+++ b/evaluate.go
@@ -224,7 +224,14 @@ func evaluateMatchExpression(expression *grammar.MatchExpression, datum interfac
 	}
 	val, err := ptr.Get(datum)
 	if err != nil {
-		return false, fmt.Errorf("error finding value in datum: %w", err)
+		if errors.Is(err, pointerstructure.ErrNotFound) && opts.withUnknown != nil {
+			err = nil
+			val = *opts.withUnknown
+		}
+
+		if err != nil {
+			return false, fmt.Errorf("error finding value in datum: %w", err)
+		}
 	}
 
 	if jn, ok := val.(json.Number); ok {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.14
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/mitchellh/pointerstructure v1.2.0
+	github.com/mitchellh/pointerstructure v1.2.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
-github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
+github.com/mitchellh/pointerstructure v1.2.1 h1:ZhBBeX8tSlRpu/FFhXH4RC4OJzFlqsQhoHZAz4x7TIw=
+github.com/mitchellh/pointerstructure v1.2.1/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/options.go
+++ b/options.go
@@ -19,6 +19,7 @@ type options struct {
 	withMaxExpressions uint64
 	withTagName        string
 	withHookFn         ValueTransformationHookFn
+	withUnknown        *interface{}
 }
 
 func WithMaxExpressions(maxExprCnt uint64) Option {
@@ -44,9 +45,20 @@ func WithHookFn(fn ValueTransformationHookFn) Option {
 	}
 }
 
+// WithUnknownValue sets a value that is used for any unknown keys. Normally,
+// bexpr will error on any expressions with unknown keys. This can be set to
+// instead use a specificed value whenever an unknown key is found. For example,
+// this might be set to the empty string "".
+func WithUnknownValue(val interface{}) Option {
+	return func(o *options) {
+		o.withUnknown = &val
+	}
+}
+
 func getDefaultOptions() options {
 	return options{
 		withMaxExpressions: 0,
 		withTagName:        "bexpr",
+		withUnknown:        nil,
 	}
 }


### PR DESCRIPTION
This introduces a new option "WithUnknownValue" that can be used to
specify some value to use for unknown keys. Normally, bexpr will error
(and this continues to be the default). However, an alternate zero value
behavior can be specified to use that instead.

This is useful for situations where you want to treat empty values as
say... empty string so that an expression generally fails but with a
false rather than an error.

This also updates to pointerstructure 1.2.1 which fixes on "not found"
case that wasn't wrapping ErrNotFound properly.