### PR TITLE
add option to skip missing map keys

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -15,12 +15,12 @@ type Filter struct {
 // For example, if you want to filter a []Foo then the data type to pass here is either []Foo or just Foo.
 // If no expression is provided the nil filter will be returned but is not an error. This is done
 // to allow for executing the nil filter which is just a no-op
-func CreateFilter(expression string) (*Filter, error) {
+func CreateFilter(expression string, opts ...Option) (*Filter, error) {
 	if expression == "" {
 		// nil filter
 		return nil, nil
 	}
-	exp, err := CreateEvaluator(expression)
+	exp, err := CreateEvaluator(expression, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create boolean expression evaluator: %v", err)
 	}

--- a/options.go
+++ b/options.go
@@ -16,10 +16,11 @@ type Option func(*options)
 
 // options = how options are represented
 type options struct {
-	withMaxExpressions uint64
-	withTagName        string
-	withHookFn         ValueTransformationHookFn
-	withUnknown        *interface{}
+	withMaxExpressions    uint64
+	withTagName           string
+	withHookFn            ValueTransformationHookFn
+	withUnknown           *interface{}
+	withSkipMissingMapKey bool
 }
 
 func WithMaxExpressions(maxExprCnt uint64) Option {
@@ -52,6 +53,21 @@ func WithHookFn(fn ValueTransformationHookFn) Option {
 func WithUnknownValue(val interface{}) Option {
 	return func(o *options) {
 		o.withUnknown = &val
+	}
+}
+
+// WithSkipMissingMapKey will cause evaluation to return false when comparing
+// against a map key that is missing. This is similar to WithUnknownValue with
+// two notable differences:
+//
+//  1. Unlike WithUnknownValue, WithSkipMissingMapKey only operates on Paths
+//     where the parent path is map.
+//  2. Unlike WithUnknownValue, WithSkipMissingMapKey always returns false.
+//
+// Using both WithUnknownValue and WithSkipMissingMapKey returns an error.
+func WithSkipMissingMapKey() Option {
+	return func(o *options) {
+		o.withSkipMissingMapKey = true
 	}
 }
 


### PR DESCRIPTION
Fixes #35 (option 2)

This adds a SkipMissingMapKey option which treats comparisons against missing maps keys as unequal.

For example with this option the expressions `Map["x"] == "y"` and `Map["x"] != "something else"` will both match when `Map["x"] = "y"`. If `Map["x"]` is unset then the `!=` operation will match since a missing key does not match any values.

I'll try to get reviews from someone on hashicorp/nomad, hashicorp/consul, and hashicorp/boundary to make sure we're all aligned.

As noted in the parent issue my preference is for hardcoding this change and dropping the Option. This PR implements the Option path to demonstrate the most complicated option. Hardcoding it means removing code and collapsing tests.