### PR TITLE
transfer maintainers to consul, boundary, and nomad

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
-* @hashicorp/release-engineering
+@hashicorp/consul-core-reviewers
+@hashicorp/boundary
+@hashicorp/github-nomad-core


### PR DESCRIPTION
This PR transfers maintainership to the Consul, Nomad, and Boundary teams as the Release Engineering team are not the correct maintainers for this repository. 