### PR TITLE
Fix benchmark evaluation to use the tests configured hooks

### DIFF
--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -616,7 +616,7 @@ func BenchmarkEvaluate(b *testing.B) {
 						b.Skip("Skipping benchmark - rerun with -bench-full to enable")
 					}
 
-					expr, err := CreateEvaluator(expTest.expression, nil)
+					expr, err := CreateEvaluator(expTest.expression, WithHookFn(expTest.hook))
 					require.NoError(b, err)
 
 					b.ResetTimer()

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,15 @@
 module github.com/hashicorp/go-bexpr
 
-go 1.14
+go 1.18
 
 require (
 	github.com/mitchellh/pointerstructure v1.2.1
 	github.com/stretchr/testify v1.8.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
When adding extra hooks previously we broke the benchmark tests. These needed this one small change to also use the common expression test configured hooks.