### PR TITLE
Set minimum version to go1.18

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - '1.14' # oldest supported; named in go.mod
+          - '1.18' # oldest supported; named in go.mod
           - 'oldstable'
           - 'stable'
     env:


### PR DESCRIPTION
This codebase now uses type `any`, introduced in go1.18, so the minimum Go version for testing must be updated to match.