### PR TITLE
CI and CODEOWNERS update

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,15 +1,18 @@
 name: Test and Build
 
 on:
+  pull_request:
+    branches: ["main"]
   push:
+    branches: ["main"]
+    tags: ["*"]
 
 permissions:
   contents: read
 
-
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
@@ -27,7 +30,7 @@ jobs:
         run: go vet ./...
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go-version:
@@ -41,13 +44,9 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
       - uses: autero1/action-gotestsum@7263b9d73912eec65f46337689e59fac865c425f # v2.0.0
         with:
           gotestsum_version: 1.9.0
 
-      - run: mkdir -p "$TEST_RESULTS"
-      - run: make test-ci
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          path: ${{ env.TEST_RESULTS }}
-          name: tests-linux
+      - run: make test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/team-ip-compliance
+* @hashicorp/team-ip-compliance @hashicorp/nomad-eng
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,6 @@ generate:
 test:
 	@go test $(TEST_VERBOSE_ARG) $(GOTEST_PKGS)
 
-test-ci:
-	@gotestsum --junitfile $(TEST_RESULTS)/gotestsum-report.xml -- $(GOTEST_PKGS)
-
 bench:
 	@go test $(TEST_VERBOSE_ARG) -run DONTRUNTESTS -bench $(BENCHTESTS) $(BENCHFULL_ARG) -benchtime=$(BENCHTIME) $(GOTEST_PKGS)
 

--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -622,6 +622,47 @@ func TestCustomTag(t *testing.T) {
 	}
 }
 
+func TestInOnOperator(t *testing.T) {
+	type testStruct struct {
+		Role  any
+		Match bool
+	}
+
+	exprs := []string{
+		"Role contains admin",
+		"admin in Role",
+	}
+	cases := []testStruct{
+		{
+			Role:  []string{"admin", "foo"},
+			Match: true,
+		},
+		{
+			Role:  "admin",
+			Match: true,
+		},
+		{
+			Role:  "dbadmin",
+			Match: true, // dangerous!
+		},
+		{
+			Role:  []string{"dbadmin", "foo"},
+			Match: false,
+		},
+	}
+
+	for _, q := range exprs {
+		expr, err := CreateEvaluator(q)
+		require.NoError(t, err)
+
+		for _, tc := range cases {
+			match, err := expr.Evaluate(tc)
+			require.NoError(t, err)
+			require.Equal(t, tc.Match, match)
+		}
+	}
+}
+
 func BenchmarkEvaluate(b *testing.B) {
 	for name, tcase := range evaluateTests {
 		// capture these values in the closure


### PR DESCRIPTION
The CI action was pretty out of date and failing: https://github.com/hashicorp/go-bexpr/actions/runs/12694928005

So I simplified it to get it working again and ease maintenance. Test failures won't be quite as pretty to view, but go-bexpr is a mature library with a small and fast test suite. I think optimizing for maintainability is best.

I also added @hashicorp/nomad-eng as a CODEOWNER so that we have a product engineering team on reviews. I'm open to opinions. Since this is such a low traffic repo I'm not too worried about it.

@hashicorp/nomad-eng will also need write access to this repo.