### PR TITLE
lint: Fix reflect inline pointer linter failure.

### DIFF
--- a/evaluate.go
+++ b/evaluate.go
@@ -63,7 +63,7 @@ func doEqualString(first interface{}, second reflect.Value) bool {
 
 // Get rid of 0 to many levels of pointers to get at the real type
 func derefType(rtype reflect.Type) reflect.Type {
-	for rtype.Kind() == reflect.Ptr {
+	for rtype.Kind() == reflect.Pointer {
 		rtype = rtype.Elem()
 	}
 	return rtype


### PR DESCRIPTION
Golang library code detail:
```go
// Ptr is the old name for the [Pointer] kind.
//
//go:fix inline
const Ptr = Pointer
```

Current failure on main: https://github.com/hashicorp/go-bexpr/actions/runs/26211483744/job/77123198783