### PR TITLE
Coerce values used for indexing a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+### Bug Fixes
+- Fixed a bug where accessing a map value using the wrong type would panic. [[GH-145](https://github.com/hashicorp/go-bexpr/pull/145)]
+
 ## 0.1.16 (March 5, 2026)
 
 ### Improvements

--- a/coerce.go
+++ b/coerce.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019, 2025
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package bexpr

--- a/coerce.go
+++ b/coerce.go
@@ -17,7 +17,7 @@ func CoerceInt64(value string) (interface{}, error) {
 
 // CoerceUint64 conforms to the FieldValueCoercionFn signature
 // and can be used to convert the raw string value of
-// an expression into an `int64`
+// an expression into a `uint64`
 func CoerceUint64(value string) (interface{}, error) {
 	i, err := strconv.ParseUint(value, 0, 64)
 	return uint64(i), err
@@ -32,7 +32,7 @@ func CoerceBool(value string) (interface{}, error) {
 
 // CoerceFloat32 conforms to the FieldValueCoercionFn signature
 // and can be used to convert the raw string value of
-// an expression into an `float32`
+// an expression into a `float32`
 func CoerceFloat32(value string) (interface{}, error) {
 	// ParseFloat always returns a float64 but ensures
 	// it can be converted to a float32 without changing
@@ -43,7 +43,7 @@ func CoerceFloat32(value string) (interface{}, error) {
 
 // CoerceFloat64 conforms to the FieldValueCoercionFn signature
 // and can be used to convert the raw string value of
-// an expression into an `float64`
+// an expression into a `float64`
 func CoerceFloat64(value string) (interface{}, error) {
 	return strconv.ParseFloat(value, 64)
 }

--- a/evaluate.go
+++ b/evaluate.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-bexpr/grammar"
+	"github.com/mitchellh/mapstructure"
 	"github.com/mitchellh/pointerstructure"
 )
 
@@ -112,7 +113,14 @@ func doMatchIn(expression *grammar.MatchExpression, value reflect.Value) (bool, 
 
 	switch kind := value.Kind(); kind {
 	case reflect.Map:
-		found := value.MapIndex(reflect.ValueOf(matchValue))
+		// If the value is a map, attempt to coerce the matchValue to
+		// the correct type used for the map key.
+		coercedValue, err := coerceMapKey(reflect.ValueOf(matchValue), value.Type().Key())
+		if err != nil {
+			return false, err
+		}
+
+		found := value.MapIndex(coercedValue)
 		return found.IsValid(), nil
 
 	case reflect.Slice, reflect.Array:
@@ -520,4 +528,33 @@ func evaluate(ast grammar.Expression, datum interface{}, opt ...Option) (bool, e
 		return evaluateCollectionExpression(node, datum, opt...)
 	}
 	return false, fmt.Errorf("invalid AST node")
+}
+
+// coerceMapKey is used for coercing a value to a specific type for
+// indexing a map, if possible. This uses the same coercion logic
+// that is used within pointerstructure to ensure consistent behvaiors.
+func coerceMapKey(value reflect.Value, to reflect.Type) (reflect.Value, error) {
+	// If it's assignable, return the value.
+	if value.Type().AssignableTo(to) {
+		return value, nil
+	}
+
+	// If it's convertible, convert it.
+	if value.Type().ConvertibleTo(to) {
+		return value.Convert(to), nil
+	}
+
+	// Create a pointer to a new value.
+	result := reflect.New(to)
+
+	// Decode into the new value.
+	if err := mapstructure.WeakDecode(value.Interface(), result.Interface()); err != nil {
+		// If the value can't be decoded, return the same error that would
+		// be returned from pointerstructure.Get.
+		return result, fmt.Errorf("%w %#v to type %s", pointerstructure.ErrConvert,
+			value.Interface(), to.String())
+	}
+
+	// Return the actual value of the converted result.
+	return reflect.Indirect(result), nil
 }

--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -369,6 +369,141 @@ var evaluateTests map[string]expressionTest = map[string]expressionTest{
 			{expression: `Nested.SliceOfPointersToStructs.1 is not nil`, result: false},
 		},
 	},
+	// Test that maps can be properly indexed with non-string types.
+	"map[string]map[int]string": {
+		map[string]map[int]string{
+			"foo": {
+				22: "ssh",
+				80: "http",
+				53: "domain",
+			},
+			"bar": nil,
+		},
+		[]expressionCheck{
+			{expression: "foo.80 == http", result: true},
+			{expression: "bar.80 == http", result: false},
+			{expression: "foo.baz == http", result: false, err: `error finding value in datum: /foo/baz at part 1: couldn't convert value "baz" to type int`},
+			{expression: "foo.22.baz == 3", result: false, err: "error finding value in datum: /foo/22/baz: at part 2, invalid value kind: string"},
+			{expression: "53 in foo", result: true},
+			{expression: "53 not in foo", result: false},
+			{expression: "99 in foo", result: false},
+			{expression: "53 in foo.baz", result: false, err: `error finding value in datum: /foo/baz at part 1: couldn't convert value "baz" to type int`},
+			{expression: "foo is not empty", result: true},
+			{expression: "foo is empty", result: false},
+		},
+	},
+	"map[string]map[int8]string": {
+		map[string]map[int8]string{
+			"foo": {
+				22: "ssh",
+				80: "http",
+				53: "domain",
+			},
+			"bar": nil,
+		},
+		[]expressionCheck{
+			{expression: "foo.80 == http", result: true},
+			{expression: "bar.80 == http", result: false},
+			{expression: "foo.baz == http", result: false, err: `error finding value in datum: /foo/baz at part 1: couldn't convert value "baz" to type int8`},
+			{expression: "foo.22.baz == 3", result: false, err: "error finding value in datum: /foo/22/baz: at part 2, invalid value kind: string"},
+			{expression: "53 in foo", result: true},
+			{expression: "53 not in foo", result: false},
+			{expression: "99 in foo", result: false},
+			{expression: "53 in foo.baz", result: false, err: `error finding value in datum: /foo/baz at part 1: couldn't convert value "baz" to type int8`},
+			{expression: "foo is not empty", result: true},
+			{expression: "foo is empty", result: false},
+		},
+	},
+	"map[string]map[float32]string": {
+		map[string]map[float32]string{
+			"foo": {
+				22:    "ssh",
+				80:    "http",
+				53:    "domain",
+				11.11: "wow",
+			},
+			"bar": nil,
+		},
+		[]expressionCheck{
+			{expression: `"/foo/11.11" == wow`, result: true},
+			{expression: "foo.80 == http", result: true},
+			{expression: "bar.80 == http", result: false},
+			{expression: "foo.baz == http", result: false, err: `error finding value in datum: /foo/baz at part 1: couldn't convert value "baz" to type float32`},
+			{expression: "foo.22.baz == 3", result: false, err: "error finding value in datum: /foo/22/baz: at part 2, invalid value kind: string"},
+			{expression: "53 in foo", result: true},
+			{expression: "53 not in foo", result: false},
+			{expression: "99 in foo", result: false},
+			{expression: "53 in foo.baz", result: false, err: `error finding value in datum: /foo/baz at part 1: couldn't convert value "baz" to type float32`},
+			{expression: "foo is not empty", result: true},
+			{expression: "foo is empty", result: false},
+		},
+	},
+	"map[string]map[bool]string": {
+		map[string]map[bool]string{
+			"foo": {
+				true:  "yes",
+				false: "no",
+			},
+			"bar": nil,
+		},
+		[]expressionCheck{
+			{expression: "foo.true == yes", result: true},
+			{expression: "foo.false == no", result: true},
+			{expression: "bar.true == yes", result: false},
+			{expression: "foo.baz == yes", result: false, err: `error finding value in datum: /foo/baz at part 1: couldn't convert value "baz" to type bool`},
+			{expression: "foo.false.baz == 3", result: false, err: "error finding value in datum: /foo/false/baz: at part 2, invalid value kind: string"},
+			{expression: "true in foo", result: true},
+			{expression: "false not in foo", result: false},
+			{expression: "foo is not empty", result: true},
+			{expression: "foo is empty", result: false},
+		},
+	},
+	"map[string]map[[1]string]string": {
+		map[string]map[[1]string]string{
+			"foo": {
+				[1]string{"baz"}: "yes",
+			},
+			"bar": nil,
+		},
+		[]expressionCheck{
+			{expression: "foo.baz == yes", result: true},
+			{expression: "baz in foo", result: true},
+			{expression: "baz in bar", result: false},
+			{expression: "foo is not empty", result: true},
+			{expression: "bar is empty", result: true},
+			{expression: "bar.baz.foo == no", result: false, err: `error finding value in datum: /bar/baz/foo at part 1: couldn't find key [1]string{"baz"}`},
+			{expression: "foo in bar.baz", result: false},
+		},
+	},
+	"map[string]map[[2]string]string": {
+		map[string]map[[2]string]string{
+			"foo": {
+				[2]string{"bar", "baz"}: "yes",
+			},
+			"bar": nil,
+		},
+		[]expressionCheck{
+			{expression: "foo.bar.baz == yes", result: false, err: `error finding value in datum: /foo/bar/baz at part 1: couldn't find key [2]string{"bar", ""}`},
+			{expression: "bar.baz in foo", result: false},
+		},
+	},
+	// With an interface type key, only string type keys can be indexed
+	// with pointerstructure so ensure contains behaves the same.
+	"map[string]map[interface{}]bool": {
+		map[string]map[interface{}]bool{
+			"foo": {
+				"baz": true,
+				22:    true,
+			},
+			"bar": nil,
+		},
+		[]expressionCheck{
+			{expression: "foo.22 == true", result: false},
+			{expression: "22 in foo", result: false},
+			{expression: "foo.baz == true", result: true},
+			{expression: "baz in foo", result: true},
+		},
+	},
 }
 
 func TestEvaluate(t *testing.T) {


### PR DESCRIPTION
## Description

When checking for the existence of a value within a map, attempt to coerce the value to the correct key type to index the map. The coercion prevents a panic when the key type of the map is anything other than a `string` type. The coercion helper matches the one used within pointerstructure to ensure consistent behavior.

## Related Issue

Fixes #144

## How Has This Been Tested?

Test coverage included.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
