### PR TITLE
fix: evaluate multi-component selectors on comparison RHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 - Fixed a bug where accessing a map value using the wrong type would panic. [[GH-145](https://github.com/hashicorp/go-bexpr/pull/145)]
+- Fixed selector-to-selector comparisons such as `value.nomad == value.consul` treating the right-hand side as a string literal. [[GH-72](https://github.com/hashicorp/go-bexpr/issues/72)]
 
 ## 0.1.16 (March 5, 2026)
 

--- a/evaluate.go
+++ b/evaluate.go
@@ -92,23 +92,29 @@ func doMatchMatches(expression *grammar.MatchExpression, value reflect.Value) (b
 	return re.Match(value.Convert(byteSliceTyp).Interface().([]byte)), nil
 }
 
-func doMatchEqual(expression *grammar.MatchExpression, value reflect.Value) (bool, error) {
+func doMatchEqual(expression *grammar.MatchExpression, value reflect.Value, datum interface{}, opt ...Option) (bool, error) {
 	// NOTE: see preconditions in evaluategrammar.MatchExpressionRecurse
 	eqFn := primitiveEqualityFn(value.Kind())
 	if eqFn == nil {
 		return false, errors.New("unable to find suitable primitive comparison function for matching")
 	}
-	matchValue, err := getMatchExprValue(expression, value.Kind())
+	matchValue, present, err := getMatchExprValue(expression, value.Kind(), datum, opt...)
 	if err != nil {
 		return false, fmt.Errorf("error getting match value in expression: %w", err)
+	}
+	if !present {
+		return false, nil
 	}
 	return eqFn(matchValue, value), nil
 }
 
-func doMatchIn(expression *grammar.MatchExpression, value reflect.Value) (bool, error) {
-	matchValue, err := getMatchExprValue(expression, value.Kind())
+func doMatchIn(expression *grammar.MatchExpression, value reflect.Value, datum interface{}, opt ...Option) (bool, error) {
+	matchValue, present, err := getMatchExprValue(expression, value.Kind(), datum, opt...)
 	if err != nil {
 		return false, fmt.Errorf("error getting match value in expression: %w", err)
+	}
+	if !present {
+		return false, nil
 	}
 
 	switch kind := value.Kind(); kind {
@@ -145,12 +151,15 @@ func doMatchIn(expression *grammar.MatchExpression, value reflect.Value) (bool, 
 				// syntax errors, so as a special case in this situation, don't
 				// error on a strconv.ErrSyntax, just continue on to the next
 				// element.
-				matchValue, err = getMatchExprValue(expression, kind)
+				matchValue, present, err = getMatchExprValue(expression, kind, datum, opt...)
 				if err != nil {
 					if errors.Is(err, strconv.ErrSyntax) {
 						continue
 					}
 					return false, errors.New(`error getting interface slice match value in expression`)
+				}
+				if !present {
+					return false, nil
 				}
 				eqFn := primitiveEqualityFn(kind)
 				if eqFn == nil {
@@ -167,9 +176,12 @@ func doMatchIn(expression *grammar.MatchExpression, value reflect.Value) (bool, 
 			// Otherwise it's a concrete type and we can essentially cache the
 			// answers. First we need to re-derive the match value for equality
 			// assertion.
-			matchValue, err = getMatchExprValue(expression, kind)
+			matchValue, present, err = getMatchExprValue(expression, kind, datum, opt...)
 			if err != nil {
 				return false, fmt.Errorf("error getting match value in expression: %w", err)
+			}
+			if !present {
+				return false, nil
 			}
 			eqFn := primitiveEqualityFn(kind)
 			if eqFn == nil {
@@ -225,29 +237,78 @@ func doMatchIsNil(matcher *grammar.MatchExpression, value reflect.Value) (bool, 
 	}
 }
 
-func getMatchExprValue(expression *grammar.MatchExpression, rvalue reflect.Kind) (interface{}, error) {
+func primitiveRaw(val interface{}) (string, error) {
+	rv := reflect.Indirect(reflect.ValueOf(val))
+	switch rv.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(rv.Bool()), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(rv.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(rv.Uint(), 10), nil
+	case reflect.Float32:
+		return strconv.FormatFloat(rv.Float(), 'g', -1, 32), nil
+	case reflect.Float64:
+		return strconv.FormatFloat(rv.Float(), 'g', -1, 64), nil
+	case reflect.String:
+		return rv.String(), nil
+	default:
+		return "", fmt.Errorf("value of type %s cannot be used as a match value", rv.Kind())
+	}
+}
+
+func getMatchExprValue(expression *grammar.MatchExpression, rvalue reflect.Kind, datum interface{}, opt ...Option) (interface{}, bool, error) {
 	if expression.Value == nil {
-		return nil, nil
+		return nil, true, nil
+	}
+
+	raw := expression.Value.Raw
+	if sel := expression.Value.Selector; sel != nil {
+		val, present, err := getValue(datum, sel.Path, opt...)
+		if err != nil {
+			return nil, false, err
+		}
+		if !present {
+			return nil, false, nil
+		}
+		if jn, ok := val.(json.Number); ok {
+			if jni, err := jn.Int64(); err == nil {
+				val = jni
+			} else if jnf, err := jn.Float64(); err == nil {
+				val = jnf
+			} else {
+				return nil, false, fmt.Errorf("unable to convert json number %s to int or float", jn)
+			}
+		}
+		raw, err = primitiveRaw(val)
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	switch rvalue {
 	case reflect.Bool:
-		return CoerceBool(expression.Value.Raw)
+		v, err := CoerceBool(raw)
+		return v, true, err
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return CoerceInt64(expression.Value.Raw)
+		v, err := CoerceInt64(raw)
+		return v, true, err
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return CoerceUint64(expression.Value.Raw)
+		v, err := CoerceUint64(raw)
+		return v, true, err
 
 	case reflect.Float32:
-		return CoerceFloat32(expression.Value.Raw)
+		v, err := CoerceFloat32(raw)
+		return v, true, err
 
 	case reflect.Float64:
-		return CoerceFloat64(expression.Value.Raw)
+		v, err := CoerceFloat64(raw)
+		return v, true, err
 
 	default:
-		return expression.Value.Raw, nil
+		return raw, true, nil
 	}
 }
 
@@ -373,17 +434,17 @@ func evaluateMatchExpression(expression *grammar.MatchExpression, datum interfac
 	rvalue := reflect.Indirect(reflect.ValueOf(val))
 	switch expression.Operator {
 	case grammar.MatchEqual:
-		return doMatchEqual(expression, rvalue)
+		return doMatchEqual(expression, rvalue, datum, opt...)
 	case grammar.MatchNotEqual:
-		result, err := doMatchEqual(expression, rvalue)
+		result, err := doMatchEqual(expression, rvalue, datum, opt...)
 		if err == nil {
 			return !result, nil
 		}
 		return false, err
 	case grammar.MatchIn:
-		return doMatchIn(expression, rvalue)
+		return doMatchIn(expression, rvalue, datum, opt...)
 	case grammar.MatchNotIn:
-		result, err := doMatchIn(expression, rvalue)
+		result, err := doMatchIn(expression, rvalue, datum, opt...)
 		if err == nil {
 			return !result, nil
 		}

--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -306,6 +306,10 @@ var evaluateTests map[string]expressionTest = map[string]expressionTest{
 			{expression: "Nested.Map.bar == `bazel`", result: false, benchQuick: true},
 			{expression: "TopInt != 0", result: true},
 			{expression: "Nested.Map contains nope or (Nested.Map contains bar and Nested.Map.bar == `bazel`) or TopInt != 0", result: true, benchQuick: true},
+			{expression: "Nested.Map.foo == Nested.Map.foo", result: true},
+			{expression: "Nested.Map.foo == Nested.Map.bar", result: false},
+			{expression: "Nested.MapOfStructs.one.Foo == Nested.MapOfStructs.one.Foo", result: true},
+			{expression: "Nested.MapOfStructs.one.Foo == Nested.MapOfStructs.two.Foo", result: false},
 			{expression: "Nested.MapOfStructs.one.Foo == 42", result: true},
 			{expression: "Nested.MapOfStructs.one.bar == `unexported`", result: false, err: `error finding value in datum: /Nested/MapOfStructs/one/bar at part 3: couldn't find key: struct field with name "bar"`},
 			{expression: "Nested.MapOfStructs.one.Baz == `exported`", result: true},
@@ -502,6 +506,42 @@ var evaluateTests map[string]expressionTest = map[string]expressionTest{
 			{expression: "22 in foo", result: false},
 			{expression: "foo.baz == true", result: true},
 			{expression: "baz in foo", result: true},
+		},
+	},
+	// Selector on the RHS of a comparison should look up the referenced
+	// value instead of treating the path as a string literal.
+	"Selector Comparison": {
+		map[string]map[string]string{
+			"value": {
+				"nomad":  "prueba",
+				"consul": "prueba",
+				"other":  "nope",
+			},
+		},
+		[]expressionCheck{
+			{expression: "value.nomad == prueba and value.consul == prueba", result: true},
+			{expression: "value.nomad == value.consul", result: true},
+			{expression: "value.nomad != value.consul", result: false},
+			{expression: "value.nomad == value.other", result: false},
+			{expression: "value.nomad != value.other", result: true},
+			{expression: `value.nomad == "value.consul"`, result: false},
+			{expression: `"/value/nomad" == "/value/consul"`, result: true},
+			{expression: "value.nomad == value.missing", result: false},
+			{expression: "value.nomad != value.missing", result: true},
+		},
+	},
+	"Selector Comparison Ints": {
+		map[string]map[string]int{
+			"nums": {
+				"x": 5,
+				"y": 5,
+				"z": 9,
+			},
+		},
+		[]expressionCheck{
+			{expression: "nums.x == nums.y", result: true},
+			{expression: "nums.x == nums.z", result: false},
+			{expression: "nums.x != nums.z", result: true},
 		},
 	},
 }

--- a/grammar/ast.go
+++ b/grammar/ast.go
@@ -135,6 +135,10 @@ func (op MatchOperator) NotPresentDisposition() bool {
 type MatchValue struct {
 	Raw       string
 	Converted interface{}
+	// Selector is set when the value was parsed as a selector with more than
+	// one path component. Evaluation looks that path up instead of using Raw
+	// as a string literal. Single-component identifiers stay literals.
+	Selector *Selector
 }
 
 type UnaryExpression struct {

--- a/grammar/grammar.go
+++ b/grammar/grammar.go
@@ -2584,7 +2584,12 @@ func (p *parser) callonIndexExpression28() (bool, error) {
 }
 
 func (c *current) onValue2(selector any) (any, error) {
-	return &MatchValue{Raw: selector.(Selector).String()}, nil
+	sel := selector.(Selector)
+	mv := &MatchValue{Raw: sel.String()}
+	if len(sel.Path) > 1 {
+		mv.Selector = &sel
+	}
+	return mv, nil
 }
 
 func (p *parser) callonValue2() (any, error) {

--- a/grammar/grammar.peg
+++ b/grammar/grammar.peg
@@ -210,7 +210,12 @@ IndexExpression "index" <- "[" _? lit:StringLiteral _? "]" {
 }
 
 Value "value" <- selector:Selector {
-   return &MatchValue{Raw:selector.(Selector).String()}, nil
+   sel := selector.(Selector)
+   mv := &MatchValue{Raw: sel.String()}
+   if len(sel.Path) > 1 {
+      mv.Selector = &sel
+   }
+   return mv, nil
 } / n:NumberLiteral {
    return &MatchValue{Raw: n.(string)}, nil
 } / s:StringLiteral {

--- a/grammar/grammar_test.go
+++ b/grammar/grammar_test.go
@@ -277,6 +277,30 @@ func TestExpressionParsing(t *testing.T) {
 			expected: &MatchExpression{Selector: Selector{Type: SelectorTypeBexpr, Path: []string{"foo", "bar", "meta", "tags", "ENV"}}, Operator: MatchIn, Value: &MatchValue{Raw: "environment"}},
 			err:      "",
 		},
+		"Match Equality Selector Value": {
+			input: "value.nomad == value.consul",
+			expected: &MatchExpression{
+				Selector: Selector{Type: SelectorTypeBexpr, Path: []string{"value", "nomad"}},
+				Operator: MatchEqual,
+				Value: &MatchValue{
+					Raw:      "value.consul",
+					Selector: &Selector{Type: SelectorTypeBexpr, Path: []string{"value", "consul"}},
+				},
+			},
+			err: "",
+		},
+		"Match Equality JSON Pointer Selector Value": {
+			input: `"/value/nomad" == "/value/consul"`,
+			expected: &MatchExpression{
+				Selector: Selector{Type: SelectorTypeJsonPointer, Path: []string{"value", "nomad"}},
+				Operator: MatchEqual,
+				Value: &MatchValue{
+					Raw:      "value/consul",
+					Selector: &Selector{Type: SelectorTypeJsonPointer, Path: []string{"value", "consul"}},
+				},
+			},
+			err: "",
+		},
 		// selectors can contain almost any character set when index expressions are used
 		// This includes whitespace, hyphens, unicode, etc.
 		"Selector Index Chars": {


### PR DESCRIPTION
## Summary
Selector-vs-selector comparisons such as `value.nomad == value.consul` were accepted by the parser but evaluated the right-hand side as the literal path string (`"value.consul"`). Multi-component (and JSON Pointer) selectors on the RHS are now looked up against the datum. Single-component identifiers such as `true` and bare string tokens stay literals.

Fixes #72

## Test plan
- [x] `go test ./...`
- [x] Added evaluate + grammar tests covering the reporter's `value.nomad == value.consul` case, inequality, missing RHS selector, and quoted literal path.